### PR TITLE
fix: Create a toolbar with different slots for the default layout

### DIFF
--- a/default-layout/ToolbarSlotsExample.tsx
+++ b/default-layout/ToolbarSlotsExample.tsx
@@ -27,6 +27,7 @@ const ToolbarSlotsExample: React.FC<{}> = () => {
                         style={{
                             alignItems: 'center',
                             display: 'flex',
+                            width: '100%',
                         }}
                     >
                         <div style={{ padding: '0px 2px' }}>


### PR DESCRIPTION
https://github.com/react-pdf-viewer/react-pdf-viewer/issues/1075